### PR TITLE
Fix CI: update-check env isolation and macOS coms socket paths

### DIFF
--- a/.pi/harnesses/lib/coms-core.test.ts
+++ b/.pi/harnesses/lib/coms-core.test.ts
@@ -28,8 +28,14 @@ function fakePi(name: string, inbound: any[]) {
 	} as any;
 }
 
+function shortTmp(prefix: string): Promise<string> {
+	// Darwin sockaddr_un is 104 bytes; GHA macOS tmpdir is already ~50 chars.
+	const base = process.platform === "darwin" ? "/tmp" : tmpdir();
+	return mkdtemp(join(base, prefix));
+}
+
 test("shared coms peers connect, discover, exchange a reply, and shut down", async () => {
-	const root = await mkdtemp(join(tmpdir(), "agent-fleet-coms-core-"));
+	const root = await shortTmp("afc-");
 	const previousComsDir = process.env.PI_COMS_DIR;
 	process.env.PI_COMS_DIR = root;
 	const { createComsPeer } = await import(`./coms-core.ts?test=${Date.now()}`);

--- a/.pi/harnesses/lib/update-check.test.ts
+++ b/.pi/harnesses/lib/update-check.test.ts
@@ -11,7 +11,13 @@ import {
 	runFleetUpdateCheck,
 	PACKAGE_NAME,
 	RELEASES_URL,
+	type FleetUpdateCheckDeps,
 } from "./update-check.ts";
+
+/** GitHub Actions sets CI=true, which the helper treats as an opt-out. */
+function enabled(extra: FleetUpdateCheckDeps = {}): FleetUpdateCheckDeps {
+	return { env: {}, ...extra };
+}
 
 function workspace(version?: string) {
 	const dir = mkdtempSync(join(tmpdir(), "af-update-check-"));
@@ -76,11 +82,25 @@ test("runFleetUpdateCheck skips hub children", async () => {
 	assert.equal(await runFleetUpdateCheck(c, { env: { AGENT_HUB_AGENT_ID: "builder" } }), null);
 });
 
+test("runFleetUpdateCheck skips when CI=true even if a cache shows an upgrade", async () => {
+	const cwd = workspace("0.1.0");
+	const cacheFile = join(mkdtempSync(join(tmpdir(), "af-update-cache-")), "latest-version.json");
+	writeFileSync(cacheFile, JSON.stringify({ latest: "0.2.0", checkedAt: Date.now() }), "utf8");
+	const { ctx: c, calls } = ctx();
+	c.cwd = cwd;
+	assert.equal(await runFleetUpdateCheck(c, {
+		env: { CI: "true" },
+		cacheFile,
+		fetchLatest: async () => "9.9.9",
+	}), null);
+	assert.equal(calls.length, 0);
+});
+
 test("runFleetUpdateCheck skips when the install record is missing", async () => {
 	const cwd = workspace();
 	const { ctx: c, calls } = ctx();
 	c.cwd = cwd;
-	assert.equal(await runFleetUpdateCheck(c, { fetchLatest: async () => "9.9.9" }), null);
+	assert.equal(await runFleetUpdateCheck(c, enabled({ fetchLatest: async () => "9.9.9" })), null);
 	assert.equal(calls.length, 0);
 });
 
@@ -91,13 +111,13 @@ test("runFleetUpdateCheck notifies from a fresh cache without fetching", async (
 	const { ctx: c, calls } = ctx();
 	c.cwd = cwd;
 	let fetched = 0;
-	const banner = await runFleetUpdateCheck(c, {
+	const banner = await runFleetUpdateCheck(c, enabled({
 		cacheFile,
 		fetchLatest: async () => {
 			fetched++;
 			return "9.9.9";
 		},
-	});
+	}));
 	assert.equal(fetched, 0);
 	assert.match(banner ?? "", /0\.1\.0 → 0\.2\.0/);
 	assert.equal(calls.length, 1);
@@ -111,10 +131,10 @@ test("runFleetUpdateCheck fetches and caches when the cache is stale", async () 
 	writeFileSync(cacheFile, JSON.stringify({ latest: "1.0.0", checkedAt: 1 }), "utf8");
 	const { ctx: c, calls } = ctx();
 	c.cwd = cwd;
-	const banner = await runFleetUpdateCheck(c, {
+	const banner = await runFleetUpdateCheck(c, enabled({
 		cacheFile,
 		fetchLatest: async () => "1.1.0",
-	});
+	}));
 	assert.match(banner ?? "", /1\.0\.0 → 1\.1\.0/);
 	assert.equal(calls.length, 1);
 	const cached = JSON.parse(readFileSync(cacheFile, "utf8"));
@@ -128,7 +148,7 @@ test("runFleetUpdateCheck stays silent when published equals recorded", async ()
 	const cacheFile = join(mkdtempSync(join(tmpdir(), "af-update-cache-")), "latest-version.json");
 	const { ctx: c, calls } = ctx();
 	c.cwd = cwd;
-	assert.equal(await runFleetUpdateCheck(c, { cacheFile, fetchLatest: async () => "2.0.0" }), null);
+	assert.equal(await runFleetUpdateCheck(c, enabled({ cacheFile, fetchLatest: async () => "2.0.0" })), null);
 	assert.equal(calls.length, 0);
 });
 
@@ -137,11 +157,11 @@ test("runFleetUpdateCheck swallows fetch failures", async () => {
 	const cacheFile = join(mkdtempSync(join(tmpdir(), "af-update-cache-")), "latest-version.json");
 	const { ctx: c, calls } = ctx();
 	c.cwd = cwd;
-	assert.equal(await runFleetUpdateCheck(c, {
+	assert.equal(await runFleetUpdateCheck(c, enabled({
 		cacheFile,
 		fetchLatest: async () => {
 			throw new Error("boom");
 		},
-	}), null);
+	})), null);
 	assert.equal(calls.length, 0);
 });

--- a/scripts/coms-cli.test.ts
+++ b/scripts/coms-cli.test.ts
@@ -25,7 +25,9 @@ interface Result {
 }
 
 function makeFixture(t: { after(fn: () => void): void }): Fixture {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), "coms-cli-test-"));
+	// Darwin sockaddr_un is 104 bytes; GHA macOS tmpdir is already ~50 chars.
+	const base = process.platform === "darwin" ? "/tmp" : os.tmpdir();
+	const root = fs.mkdtempSync(path.join(base, "afcl-"));
 	const fixture = { root, coms: path.join(root, "coms") };
 	t.after(() => fs.rmSync(root, { recursive: true, force: true }));
 	return fixture;


### PR DESCRIPTION
## Why
[Release run 34452427047](https://github.com/chankov/agent-fleet/actions/runs/34452427047) failed:

- **ubuntu + macos:** `runFleetUpdateCheck` notify/cache tests returned null because Actions sets `CI=true`, and the helper treats that as an opt-out.
- **macos only:** `coms-core` bind and `coms-cli _listen` hit `listen EINVAL` — Darwin `sockaddr_un` is 104 bytes and the GHA macOS tmpdir is already ~50 characters.

## What
- Update-check tests that must actually run pass `env: {}`. Added a regression that `CI=true` still skips.
- coms-core and coms-cli fixtures `mkdtemp` under `/tmp` on darwin.

Test-only; no runtime change.